### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Build project
         run: |
           go build .
-          zip --junk-paths moxxiproxy
+          zip --junk-paths moxxiproxy.zip moxxiproxy
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,43 @@
+on:
+  push:
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Upload Release Asset
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Get Golang
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.18.2'
+        run: go version
+      - name: Build project
+        run: |
+          go build .
+          zip --junk-paths moxxiproxy
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./moxxiproxy.zip
+          asset_name: moxxiproxy.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: '1.18.2'
-        run: go version
+      - run: go version
       - name: Build project
         run: |
           go build .


### PR DESCRIPTION
This creates a release every time you push a new tag that starts with `v` to the repository.

Example:

```
git tag -a v2.0 -m "Version 2.0"
git push --tags
```

The command above will push the newly created `v2.0` tag and trigger the workflow, creating a new `Release v2.0`. After that, it's possible to download a `moxxiproxy.zip` file that contains the proxy's binary built on ubuntu 20.04 with Go 1.18.2.